### PR TITLE
Altered Go version verification to compare by numerical value

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -116,6 +116,7 @@ func executablePath(name string) string {
 }
 
 func main() {
+	fmt.Printf("GOBIN: %s\n", GOBIN)
 	log.SetFlags(log.Lshortfile)
 
 	if _, err := os.Stat(filepath.Join("build", "ci.go")); os.IsNotExist(err) {
@@ -162,7 +163,7 @@ func doInstall(cmdline []string) {
 		var minor int
 		fmt.Sscanf(strings.TrimPrefix(runtime.Version(), "go1."), "%d", &minor)
 
-		if minor < 9 {
+		if minor < 4 {
 			log.Println("You have Go version", runtime.Version())
 			log.Println("go-dubaicoin requires at least Go version 1.4 and cannot")
 			log.Println("be compiled with an earlier version. Please upgrade your Go installation.")
@@ -220,17 +221,21 @@ func buildFlags(env build.Environment) (flags []string) {
 		flags = append(flags, "-tags", "opencl")
 	}
 
+	var minor int
+	fmt.Sscanf(strings.TrimPrefix(runtime.Version(), "go1."), "%d", &minor)
+
 	// Since Go 1.5, the separator char for link time assignments
 	// is '=' and using ' ' prints a warning. However, Go < 1.5 does
 	// not support using '='.
 	sep := " "
-	if runtime.Version() > "go1.5" || strings.Contains(runtime.Version(), "devel") {
+	if if minor > 5 || strings.Contains(runtime.Version(), "devel") {
 		sep = "="
 	}
 	// Set gitCommit constant via link-time assignment.
 	if env.Commit != "" {
 		flags = append(flags, "-ldflags", "-X main.gitCommit"+sep+env.Commit)
 	}
+	fmt.Printf("FLAGS: %s\n", flags)
 	return flags
 }
 

--- a/build/ci.go
+++ b/build/ci.go
@@ -157,11 +157,17 @@ func doInstall(cmdline []string) {
 
 	// Check Go version. People regularly open issues about compilation
 	// failure with outdated Go. This should save them the trouble.
-	if runtime.Version() < "go1.4" && !strings.HasPrefix(runtime.Version(), "devel") {
-		log.Println("You have Go version", runtime.Version())
-		log.Println("go-ethereum requires at least Go version 1.4 and cannot")
-		log.Println("be compiled with an earlier version. Please upgrade your Go installation.")
-		os.Exit(1)
+	if !strings.Contains(runtime.Version(), "devel") {
+		// Figure out the minor version number since we can't textually compare (1.10 < 1.9)
+		var minor int
+		fmt.Sscanf(strings.TrimPrefix(runtime.Version(), "go1."), "%d", &minor)
+
+		if minor < 9 {
+			log.Println("You have Go version", runtime.Version())
+			log.Println("go-dubaicoin requires at least Go version 1.4 and cannot")
+			log.Println("be compiled with an earlier version. Please upgrade your Go installation.")
+			os.Exit(1)
+		}
 	}
 	// Compile packages given as arguments, or everything if there are no arguments.
 	packages := []string{"./..."}
@@ -354,7 +360,7 @@ func doArchive(cmdline []string) {
 	var (
 		env      = build.Env()
 		base     = archiveBasename(*arch, env)
-		gdbix     = "gdbix-" + base + ext
+		gdbix    = "gdbix-" + base + ext
 		alltools = "gdbix-alltools-" + base + ext
 	)
 	maybeSkipArchive(env)
@@ -654,7 +660,7 @@ func doWindowsInstaller(cmdline []string) {
 	// first section contains the gdbix binary, second section holds the dev tools.
 	templateData := map[string]interface{}{
 		"License":  "COPYING",
-		"Gdbix":     gethTool,
+		"Gdbix":    gethTool,
 		"DevTools": devTools,
 	}
 	build.Render("build/nsis.gdbix.nsi", filepath.Join(*workdir, "gdbix.nsi"), 0644, nil)

--- a/build/ci.go
+++ b/build/ci.go
@@ -228,7 +228,7 @@ func buildFlags(env build.Environment) (flags []string) {
 	// is '=' and using ' ' prints a warning. However, Go < 1.5 does
 	// not support using '='.
 	sep := " "
-	if if minor > 5 || strings.Contains(runtime.Version(), "devel") {
+	if minor > 5 || strings.Contains(runtime.Version(), "devel") {
 		sep = "="
 	}
 	// Set gitCommit constant via link-time assignment.


### PR DESCRIPTION
**Previous version**

Prior to building, the build script checks to ensure that the Go version is 1.4 or greater, however, it does this check by looking at string values, so Go v1.10 evaluates as unacceptable.

**Change**

This changes the manner of the compare to numerical, allowing 1.4 to evaluate as earlier than 1.10.